### PR TITLE
Bump httpcomponents

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -53,6 +53,8 @@ jobs:
       - name: Build and push image to registry
         id: docker_build
         uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_SUMMARY: false
         with:
           context: '.'
           file: Dockerfile.crf

--- a/build.gradle
+++ b/build.gradle
@@ -405,6 +405,8 @@ project(":grobid-service") {
         implementation 'io.dropwizard:dropwizard-json-logging:4.0.12'
 
         implementation "org.apache.pdfbox:pdfbox:2.0.26"
+        implementation "org.apache.httpcomponents.client5:httpclient5:5.4.4"
+
         implementation "javax.activation:activation:1.1.1"
         implementation "io.prometheus:simpleclient_dropwizard:0.16.0"
         implementation "io.prometheus:simpleclient_servlet:0.16.0"


### PR DESCRIPTION
Summary: As above. Resolves `CVE-2025-27820`.

Test plan: Verify that Grobid still works as expected.

Issue number/task: n/a
